### PR TITLE
Update dependencies and JDK versions

### DIFF
--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -9,10 +9,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
+    - uses: actions/checkout@v4
+    - name: Set up Adopt OpenJDK 17
+      uses: actions/setup-java@v4
       with:
-        java-version: 11
+        distribution: adopt
+        java-version: '17'
     - name: Build with Maven
       run: mvn -B verify

--- a/.github/workflows/openapi-maven-release.yml
+++ b/.github/workflows/openapi-maven-release.yml
@@ -8,11 +8,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
+    - uses: actions/checkout@v4
+    - name: Set up Adopt OpenJDK 17
+      uses: actions/setup-java@v4
       with:
-        java-version: 11
+        distribution: adopt
+        java-version: '17'
         server-id: ossrh
         server-username: OPENAPI_OSSRH_USERNAME
         server-password: OPENAPI_OSSRH_TOKEN

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -31,7 +31,13 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>2.8.0</version>
+            <version>2.9.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>5.3.29</version>
+            <version>6.1.12</version>
         </dependency>
         <dependency>
             <groupId>org.openapi4j</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -33,6 +33,7 @@
             <artifactId>json-path</artifactId>
             <version>2.9.0</version>
             <exclusions>
+<!--                SLF4J excluded because it took precedence over the intended logback configuration.-->
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <javaVersion>11</javaVersion>
+        <javaVersion>17</javaVersion>
         <maven.compiler.release>${javaVersion}</maven.compiler.release> <!-- has to io set using property for kie-maven-plugin -->
         <maven.compiler.source>${javaVersion}</maven.compiler.source>
         <maven.compiler.target>${javaVersion}</maven.compiler.target>

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,11 @@
 
 The belgif-rest-guide-validator Plugin is used to validate a Swagger API to conforms the Belgif standards (https://www.belgif.be/specification/rest/api-guide/).
 
-*Note: the services-rest-parent use this plugin and the result is visible in Jenkins Test results*
+# Prerequisites
+This Maven plugin requires JDK 17 or higher to be used in the Maven runtime. 
+Note that the JDK version used to compile the source code of the project can differ. 
+IDEs may need manual configuration to set the appropriate Maven runtime JDK version.
+
 ## Goal Overview
 The goal api-validator has as default phase the LifecyclePhase.PREPARE_PACKAGE.
 

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,7 @@ This Maven plugin requires JDK 17 or higher to be used in the Maven runtime.
 Note that the JDK version used to compile the source code of the project can differ. 
 IDEs may need manual configuration to set the appropriate Maven runtime JDK version.
 The minimum maven version is 3.8.5
+
 ## Goal Overview
 The goal api-validator has as default phase the LifecyclePhase.PREPARE_PACKAGE.
 

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ The belgif-rest-guide-validator Plugin is used to validate a Swagger API to conf
 This Maven plugin requires JDK 17 or higher to be used in the Maven runtime. 
 Note that the JDK version used to compile the source code of the project can differ. 
 IDEs may need manual configuration to set the appropriate Maven runtime JDK version.
-
+The minimum maven version is 3.8.5
 ## Goal Overview
 The goal api-validator has as default phase the LifecyclePhase.PREPARE_PACKAGE.
 


### PR DESCRIPTION
Updated dependencies where dependabot failed:

Bump com.jayway.jsonpath:json-path from 2.8.0 to 2.9.0 failed because it imported SLF4j which took precedence over logback (failing compilation and tests) -> excluded slf4j from the import.

Bump org.springframework:spring-web from 5.3.29 to 6.0.19 failed because maven was configured for java 11. Updated to spring 6.1.12, set JDK 17 and updated github workflows.

Review -> verify if it's okay to drop java 11 support.