### PR TITLE
Fix github actions and fix deploy issues

### DIFF
--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -9,12 +9,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-#    - uses: actions/checkout@v4
-#    - name: Set up Adopt OpenJDK 17
-#      uses: actions/setup-java@v4
-#      with:
-#        distribution: adopt
-#        java-version: '17'
     - name: Setup Maven Action
       uses: s4u/setup-maven-action@v1.14.0
       with:

--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -9,11 +9,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Adopt OpenJDK 17
-      uses: actions/setup-java@v4
+#    - uses: actions/checkout@v4
+#    - name: Set up Adopt OpenJDK 17
+#      uses: actions/setup-java@v4
+#      with:
+#        distribution: adopt
+#        java-version: '17'
+    - name: Setup Maven Action
+      uses: s4u/setup-maven-action@v1.14.0
       with:
-        distribution: adopt
         java-version: '17'
+        java-distribution: 'adopt'
+        maven-version: '3.9.9'
     - name: Build with Maven
       run: mvn -B verify

--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+#    Setup Maven action to specify maven version > required for BUG https://issues.apache.org/jira/browse/MNG-7055
     - name: Setup Maven Action
       uses: s4u/setup-maven-action@v1.14.0
       with:

--- a/.github/workflows/openapi-maven-release.yml
+++ b/.github/workflows/openapi-maven-release.yml
@@ -9,14 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Adopt OpenJDK 17
-      uses: actions/setup-java@v4
+    - name: Setup Maven Action
+      uses: s4u/setup-maven-action@v1.14.0
       with:
-        distribution: adopt
         java-version: '17'
-        server-id: ossrh
-        server-username: MAVEN_CENTRAL_USER
-        server-password: MAVEN_CENTRAL_TOKEN
+        java-distribution: 'adopt'
+        maven-version: '3.9.9'
+        settings-servers: [{"id": "ossrh", "username": MAVEN_CENTRAL_USER, "password": MAVEN_CENTRAL_TOKEN}]
     - name: Build with Maven
       run: mvn -B deploy -Drevision=${GITHUB_REF_NAME:1} -Prelease
       env:

--- a/.github/workflows/openapi-maven-release.yml
+++ b/.github/workflows/openapi-maven-release.yml
@@ -8,7 +8,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+#    Setup Maven action to specify maven version > required for BUG https://issues.apache.org/jira/browse/MNG-7055
     - name: Setup Maven Action
       uses: s4u/setup-maven-action@v1.14.0
       with:

--- a/.github/workflows/openapi-maven-release.yml
+++ b/.github/workflows/openapi-maven-release.yml
@@ -25,6 +25,8 @@ jobs:
         MAVEN_CENTRAL_USER: ${{ secrets.OPENAPI_OSSRH_USERNAME }}
         MAVEN_CENTRAL_TOKEN: ${{ secrets.OPENAPI_OSSRH_TOKEN }}
     - name: Create GitHub release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh release create ${GITHUB_REF} --draft --title "Release ${GITHUB_REF_NAME}" --notes "Changes:
         - [placeholder]"

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -12,6 +12,10 @@
 
     <artifactId>belgif-rest-guide-validator-integrationtest</artifactId>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.github.belgif.rest.guide.validator</groupId>


### PR DESCRIPTION
- Fixed github release step in release action
- Added maven.deploy.skip for integrationtests
- TODO: Find a way to control the maven version used by the build / release job: https://issues.apache.org/jira/browse/MNG-7055 https://github.com/actions/setup-java/issues/457

possible solution: https://github.com/marketplace/actions/setup-maven-action

using maven-action seems to work for the build job. Documentation is not clear in setting the server settings for the release job. Probably to try out?