### PR TITLE
Bugfix: Discriminator references in example validation

### DIFF
--- a/core/src/main/java/org/openapi4j/schema/validator/v3/DiscriminatorValidator.java
+++ b/core/src/main/java/org/openapi4j/schema/validator/v3/DiscriminatorValidator.java
@@ -236,11 +236,13 @@ abstract class DiscriminatorValidator extends BaseJsonValidator<OAI3> {
 
         // Check if Schema Object exists
         // Modification for Belgif validator: Resolve relative refs
-//        return context.getContext().getReferenceRegistry().getRef(ref) != null;
         return resolveRelativeRef(ref) != null;
     }
 
-    //    Custom method for Belgif Validator to resolve ref
+    /**
+     * Custom method for Belgif Validator
+     * Resolves the reference within the discriminatorMapping
+     */
     private Reference resolveRelativeRef(String ref) {
         List<String> refCrumbs = new ArrayList<>();
         addExternalRefCrumb(this.crumbInfo, refCrumbs);
@@ -258,11 +260,17 @@ abstract class DiscriminatorValidator extends BaseJsonValidator<OAI3> {
         }
     }
 
-    private static String getComponentRef(String ref) { // to only fetch the part after #
+    /**
+     * Returns only the reference within a file
+     */
+    private static String getComponentRef(String ref) {
         String[] refSplit = ref.split("#/");
         return "#/" + refSplit[refSplit.length - 1];
     }
 
+    /**
+     * Returns an absolute reference String based on the crumbInfo found in the validators
+     */
     private static String buildRef(List<String> refCrumbs, String ref, Path basePath) {
         if (refCrumbs.isEmpty()) {
             return ref;

--- a/core/src/main/java/org/openapi4j/schema/validator/v3/SchemaValidator.java
+++ b/core/src/main/java/org/openapi4j/schema/validator/v3/SchemaValidator.java
@@ -1,0 +1,225 @@
+package org.openapi4j.schema.validator.v3;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import org.openapi4j.core.exception.ResolutionException;
+import org.openapi4j.core.model.v3.OAI3;
+import org.openapi4j.core.model.v3.OAI3Context;
+import org.openapi4j.core.validation.ValidationException;
+import org.openapi4j.core.validation.ValidationResults;
+import org.openapi4j.schema.validator.BaseJsonValidator;
+import org.openapi4j.schema.validator.JsonValidator;
+import org.openapi4j.schema.validator.ValidationContext;
+import org.openapi4j.schema.validator.ValidationData;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.openapi4j.core.model.v3.OAI3SchemaKeywords.*;
+import static org.openapi4j.schema.validator.v3.ValidationOptions.ADDITIONAL_PROPS_RESTRICT;
+
+/**
+ * This class overrides <a href="https://github.com/openapi4j/openapi4j/blob/master/openapi-schema-validator/src/main/java/org/openapi4j/schema/validator/v3/SchemaValidator.java">this class of the OpenApi4j SchemaValidator</a>.
+ * Added a getCrumbInfo in order to resolve nested relative references for discriminators
+ */
+
+/**
+ * Schema validation implementation.
+ * This is the entry point of all validators.
+ */
+public class SchemaValidator extends BaseJsonValidator<OAI3> {
+    private static final JsonNode FALSE_NODE = JsonNodeFactory.instance.booleanNode(false);
+
+    private final ValidationResults.CrumbInfo crumbInfo;
+    private final Map<String, Collection<JsonValidator>> validators;
+
+    /**
+     * Create a new Schema Object validator.
+     * A new context will be created with 'file:/' as base URL.
+     *
+     * @param propertyName The property or root name of the schema. Can be {@code null}.
+     * @param schemaNode   The schema specification.
+     * @throws ResolutionException for wrong references.
+     */
+    public SchemaValidator(final String propertyName, final JsonNode schemaNode) throws ResolutionException {
+        this(
+                new ValidationContext<>(new OAI3Context(getDefaultBaseUrl(), schemaNode)),
+                new ValidationResults.CrumbInfo(propertyName, false),
+                schemaNode, null, null);
+    }
+
+    /**
+     * Create a new Schema Object validator with the given context.
+     * Warning: {@code schemaNode} must be associated with {@code context} via
+     * {@code new OAI3Context(URL, schemaNode)} in case of JSON-references.
+     *
+     * @param context      The context to use for validation.
+     * @param propertyName The property or root name of the schema. Can be {@code null}.
+     * @param schemaNode   The schema specification.
+     */
+    public SchemaValidator(final ValidationContext<OAI3> context,
+                           final String propertyName,
+                           final JsonNode schemaNode) {
+
+        this(context, new ValidationResults.CrumbInfo(propertyName, false), schemaNode, null, null);
+    }
+
+    /**
+     * Create a new Schema Object validator with the given context.
+     *
+     * @param context          The context to use for validation.
+     * @param crumbInfo        The property or root name of the schema.
+     * @param schemaNode       The schema specification.
+     * @param schemaParentNode The tree node of the parent schema.
+     * @param parentSchema     The parent schema model.
+     */
+    SchemaValidator(final ValidationContext<OAI3> context,
+                    final ValidationResults.CrumbInfo crumbInfo,
+                    final JsonNode schemaNode,
+                    final JsonNode schemaParentNode,
+                    final SchemaValidator parentSchema) {
+
+        super(context, schemaNode, schemaParentNode, parentSchema);
+
+        this.crumbInfo = crumbInfo;
+        validators = read(this.context, schemaNode);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean validate(final JsonNode valueNode, final ValidationData<?> validation) {
+        try {
+            validateWithContext(valueNode, validation);
+        } catch (ValidationException ignored) {
+            // results are already populated
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the context of validation.
+     */
+    public ValidationContext<OAI3> getContext() {
+        return context;
+    }
+
+    SchemaValidator findParent() {
+        return (getParentSchema() != null) ? getParentSchema().findParent() : this;
+    }
+
+    final void validateWithContext(JsonNode valueNode, final ValidationData<?> validation) throws ValidationException {
+        if (valueNode == null) {
+            valueNode = JsonNodeFactory.instance.nullNode();
+        }
+
+        if (context.isFastFail()) {
+            fastFailValidate(valueNode, validation);
+        } else {
+            defaultValidate(valueNode, validation);
+        }
+    }
+
+    private void fastFailValidate(final JsonNode valueNode, final ValidationData<?> validation) throws ValidationException {
+        validation.results().withCrumb(crumbInfo, () -> {
+            for (Collection<JsonValidator> keywordValidators : validators.values()) {
+                for (JsonValidator validator : keywordValidators) {
+                    boolean shouldChain = validator.validate(valueNode, validation);
+
+                    if (!validation.isValid()) {
+                        return;
+                    }
+
+                    if (!shouldChain) {
+                        break;
+                    }
+                }
+            }
+        });
+
+        if (!validation.isValid()) {
+            throw new ValidationException(null, validation.results());
+        }
+    }
+
+    private void defaultValidate(final JsonNode valueNode, final ValidationData<?> validation) {
+        validation.results().withCrumb(crumbInfo, () -> {
+            for (Collection<JsonValidator> keywordValidators : validators.values()) {
+                for (JsonValidator validator : keywordValidators) {
+                    if (!validator.validate(valueNode, validation)) {
+                        break;
+                    }
+                }
+            }
+        });
+    }
+
+    /**
+     * Read the schema and create dedicated validators from keywords.
+     */
+    private Map<String, Collection<JsonValidator>> read(final ValidationContext<OAI3> context, final JsonNode schemaNode) {
+        Map<String, Collection<JsonValidator>> validatorMap = new HashMap<>();
+
+        Iterator<String> fieldNames = schemaNode.fieldNames();
+        while (fieldNames.hasNext()) {
+            final String keyword = fieldNames.next();
+            final JsonNode keywordSchemaNode = schemaNode.get(keyword);
+
+            Collection<JsonValidator> keywordValidators = ValidatorsRegistry.instance().getValidators(context, keyword, keywordSchemaNode, schemaNode, this);
+            if (keywordValidators != null) {
+                validatorMap.put(keyword, keywordValidators);
+            }
+        }
+
+        applyAdditionalValidators(validatorMap, schemaNode);
+
+        return validatorMap;
+    }
+
+    private void applyAdditionalValidators(final Map<String, Collection<JsonValidator>> validatorMap,
+                                           final JsonNode schemaNode) {
+
+        // Apply additional validators if not JSON-Reference
+        if (validatorMap.containsKey($REF)) {
+            return;
+        }
+
+        // Setup optional restriction for additional properties
+        if (validatorMap.get(ADDITIONALPROPERTIES) == null && context.getOption(ADDITIONAL_PROPS_RESTRICT)) {
+            validatorMap.put(
+                    ADDITIONALPROPERTIES,
+                    ValidatorsRegistry.instance().getValidators(context, ADDITIONALPROPERTIES, FALSE_NODE, schemaNode, this));
+        }
+
+        // Setup default nullable schema to false
+        // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#schemaNullable
+        validatorMap.computeIfAbsent(
+                NULLABLE,
+                s -> ValidatorsRegistry.instance().getValidators(context, s, FALSE_NODE, schemaNode, this));
+    }
+
+    /**
+     * Make quietly a default base URL for context.
+     *
+     * @return default base URL for context.
+     */
+    private static URL getDefaultBaseUrl() {
+        try {
+            return new URL("file:/");
+        } catch (MalformedURLException ignored) {
+            // Will never happen
+            return null;
+        }
+    }
+
+    public ValidationResults.CrumbInfo getCrumbInfo() {
+        return crumbInfo;
+    }
+
+}

--- a/rules/src/test/java/io/github/belgif/rest/guide/validator/rules/oas/ExamplesShouldValidateAgainstSchemaTest.java
+++ b/rules/src/test/java/io/github/belgif/rest/guide/validator/rules/oas/ExamplesShouldValidateAgainstSchemaTest.java
@@ -77,4 +77,19 @@ class ExamplesShouldValidateAgainstSchemaTest extends AbstractOasRuleTest {
         assertErrorCount(1, callRules("schemaInExternalFile.yaml"));
     }
 
+    @Test
+    void testDiscriminatorRefs() {
+        assertNoViolations(callRules("discriminatorRefs/discriminator.yaml"));
+    }
+
+    @Test
+    void testComplexDiscriminatorRefs() {
+        assertNoViolations(callRules("discriminatorRefs/complexDiscriminator.yaml"));
+    }
+
+    @Test
+    void testFailingDiscriminatorRefs() {
+        assertErrorCount(1, callRules("discriminatorRefs/failingDiscriminator.yaml"));
+    }
+
 }

--- a/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/examplesShouldValidateAgainstSchema/discriminatorRefs/complex/childs/schemas.yaml
+++ b/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/examplesShouldValidateAgainstSchema/discriminatorRefs/complex/childs/schemas.yaml
@@ -1,0 +1,24 @@
+openapi: "3.0.3"
+info:
+  title: "My Test"
+  version: "0.3"
+paths: {}
+components:
+  schemas:
+    FirstChild:
+      description: description
+      allOf:
+        - $ref: "../main/schemas.yaml#/components/schemas/TopLevel"
+        - type: object
+          properties:
+            firstChildProperty:
+              type: string
+
+    SecondChild:
+      description: Doesnt matter
+      allOf:
+        - $ref: "../main/schemas.yaml#/components/schemas/TopLevel"
+        - type: object
+          properties:
+            secondChildProperty:
+              type: string

--- a/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/examplesShouldValidateAgainstSchema/discriminatorRefs/complex/main/schemas.yaml
+++ b/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/examplesShouldValidateAgainstSchema/discriminatorRefs/complex/main/schemas.yaml
@@ -1,0 +1,22 @@
+openapi: "3.0.3"
+info:
+  title: "My Test"
+  version: "0.3"
+paths: {}
+components:
+  schemas:
+    TopLevel:
+      type: object
+      description: description
+      required:
+        - objectType
+      properties:
+        objectType:
+          $ref: "../object/schemas.yaml#/components/schemas/ObjectType"
+        topLevelProperty:
+          type: string
+      discriminator:
+        propertyName: objectType
+        mapping:
+          firstChild: "../childs/schemas.yaml#/components/schemas/FirstChild"
+          secondChild: "../childs/schemas.yaml#/components/schemas/SecondChild"

--- a/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/examplesShouldValidateAgainstSchema/discriminatorRefs/complex/object/schemas.yaml
+++ b/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/examplesShouldValidateAgainstSchema/discriminatorRefs/complex/object/schemas.yaml
@@ -1,0 +1,13 @@
+openapi: "3.0.3"
+info:
+  title: "My Test"
+  version: "0.3"
+paths: {}
+components:
+  schemas:
+    ObjectType:
+      type: string
+      enum:
+        - firstChild
+        - secondChild
+      description: type of thing

--- a/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/examplesShouldValidateAgainstSchema/discriminatorRefs/complexDiscriminator.yaml
+++ b/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/examplesShouldValidateAgainstSchema/discriminatorRefs/complexDiscriminator.yaml
@@ -1,0 +1,23 @@
+openapi: "3.0.3"
+info:
+  title: "My Test"
+  version: "0.3"
+paths: {}
+components:
+  schemas:
+    myRequest:
+      description: Doesn't matter
+      type: object
+      properties:
+        testRequest:
+          $ref: 'schemas/testRequest.yaml#/components/schemas/TestRequest'
+      example: {
+        "testRequest" : {
+          "myFirstProperty": "yes",
+          "schemaUnderTest": {
+            "objectType": "firstChild",
+            "dataSource": "myDataSource",
+            "firstChildProperty": "seems good"
+          }
+        }
+      }

--- a/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/examplesShouldValidateAgainstSchema/discriminatorRefs/discriminator.yaml
+++ b/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/examplesShouldValidateAgainstSchema/discriminatorRefs/discriminator.yaml
@@ -1,0 +1,30 @@
+openapi: "3.0.3"
+info:
+  title: "My Test"
+  version: "0.3"
+paths: {}
+components:
+  schemas:
+    TestRequest:
+      description: Doesn't matter
+      allOf:
+        - type: object
+        - type: object
+          required:
+            - schemaUnderTest
+          properties:
+            myFirstProperty:
+              type: string
+              description: a property
+            schemaUnderTest:
+              allOf:
+                - $ref: "schemas/schemas.yaml#/components/schemas/FirstChild"
+                - description: nope
+      example: {
+        "myFirstProperty": "yes",
+        "schemaUnderTest": {
+          "objectType": "firstChild",
+          "dataSource": "myDataSource",
+          "firstChildProperty": "seems good"
+        }
+      }

--- a/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/examplesShouldValidateAgainstSchema/discriminatorRefs/failingDiscriminator.yaml
+++ b/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/examplesShouldValidateAgainstSchema/discriminatorRefs/failingDiscriminator.yaml
@@ -1,0 +1,30 @@
+openapi: "3.0.3"
+info:
+  title: "My Test"
+  version: "0.3"
+paths: {}
+components:
+  schemas:
+    TestRequest:
+      description: Doesn't matter
+      allOf:
+        - type: object
+        - type: object
+          required:
+            - schemaUnderTest
+          properties:
+            myFirstProperty:
+              type: string
+              description: a property
+            schemaUnderTest:
+              allOf:
+                - $ref: "failingSchemas.yaml#/components/schemas/FirstChild"
+                - description: nope
+      example: {
+        "myFirstProperty": "yes",
+        "schemaUnderTest": {
+          "objectType": "firstChild",
+          "dataSource": "myDataSource",
+          "firstChildProperty": "seems good"
+        }
+      }

--- a/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/examplesShouldValidateAgainstSchema/discriminatorRefs/failingSchemas.yaml
+++ b/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/examplesShouldValidateAgainstSchema/discriminatorRefs/failingSchemas.yaml
@@ -1,0 +1,47 @@
+openapi: "3.0.3"
+info:
+  title: "My Test"
+  version: "0.3"
+paths: {}
+components:
+  schemas:
+    FirstChild:
+      description: description
+      allOf:
+        - $ref: "#/components/schemas/TopLevel"
+        - type: object
+          properties:
+            firstChildProperty:
+              type: string
+
+    SecondChild:
+      description: Doesnt matter
+      allOf:
+        - $ref: "#/components/schemas/TopLevel"
+        - type: object
+          properties:
+            secondChildProperty:
+              type: string
+
+    TopLevel:
+      type: object
+      description: description
+      required:
+        - objectType
+      properties:
+        objectType:
+          $ref: "#/components/schemas/ObjectType"
+        topLevelProperty:
+          type: string
+      discriminator:
+        propertyName: objectType
+        mapping:
+          firstChild: "#/components/schemas/DoesNotExist"
+          secondChild: "#/components/schemas/SecondChild"
+
+    ObjectType:
+      type: string
+      enum:
+        - firstChild
+        - secondChild
+      description: type of thing

--- a/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/examplesShouldValidateAgainstSchema/discriminatorRefs/schemas/schemas.yaml
+++ b/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/examplesShouldValidateAgainstSchema/discriminatorRefs/schemas/schemas.yaml
@@ -1,0 +1,47 @@
+openapi: "3.0.3"
+info:
+  title: "My Test"
+  version: "0.3"
+paths: {}
+components:
+  schemas:
+    FirstChild:
+      description: description
+      allOf:
+        - $ref: "#/components/schemas/TopLevel"
+        - type: object
+          properties:
+            firstChildProperty:
+              type: string
+
+    SecondChild:
+      description: Doesnt matter
+      allOf:
+        - $ref: "#/components/schemas/TopLevel"
+        - type: object
+          properties:
+            secondChildProperty:
+              type: string
+
+    TopLevel:
+      type: object
+      description: description
+      required:
+        - objectType
+      properties:
+        objectType:
+          $ref: "#/components/schemas/ObjectType"
+        topLevelProperty:
+          type: string
+      discriminator:
+        propertyName: objectType
+        mapping:
+          firstChild: "#/components/schemas/FirstChild"
+          secondChild: "#/components/schemas/SecondChild"
+
+    ObjectType:
+      type: string
+      enum:
+        - firstChild
+        - secondChild
+      description: type of thing

--- a/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/examplesShouldValidateAgainstSchema/discriminatorRefs/schemas/testRequest.yaml
+++ b/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/examplesShouldValidateAgainstSchema/discriminatorRefs/schemas/testRequest.yaml
@@ -1,0 +1,22 @@
+openapi: "3.0.3"
+info:
+  title: "My Test"
+  version: "0.3"
+paths: {}
+components:
+  schemas:
+    TestRequest:
+      description: Doesn't matter
+      allOf:
+        - type: object
+        - type: object
+          required:
+            - schemaUnderTest
+          properties:
+            myFirstProperty:
+              type: string
+              description: a property
+            schemaUnderTest:
+              allOf:
+                - $ref: "../complex/childs/schemas.yaml#/components/schemas/FirstChild"
+                - description: nope


### PR DESCRIPTION
There is a bug in the openapi4j library which didn't correctly resolved the discriminator mapping refs in nested files.
It always assumed the reference in the schema mapping was relative to the 'entry file' (the file which usually contains the paths etc).

Did another override of the DiscriminatorValidator of the openapi4j lib in our project and included testcases.

Ready for review. 