### PR TITLE
Add exception to rule Mandatory Mediatypes

### DIFF
--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-MandatoryMediaType.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-MandatoryMediaType.drl
@@ -27,6 +27,8 @@ rule "Mandatory Mediatype"
     eval( $schema != null )
     $schemaDefinition: SchemaDefinition(model.getType() != SchemaType.STRING || (model.getFormat() != "binary" && model.getFormat != "byte" && model.getFormat != "base64")) from parserResult.resolve($schema)
     eval( !ApiFunctions.isMediaTypeIncluded($mediaTypeDefinition.getIdentifier(), includedMediaTypes()) )
+    // text/* should only be allowed for type string, not for objects
+    eval( !(ApiFunctions.isMediaTypeIncluded($mediaTypeDefinition.getIdentifier(), Set.of("text/*")) && $schemaDefinition.getModel().getType().equals(SchemaType.STRING)) )
   then
     violationMandatoryMediaType(oas, $mediaTypeDefinition);
 end

--- a/rules/src/test/java/io/github/belgif/rest/guide/validator/rules/oas/MandatoryMediaTypeTest.java
+++ b/rules/src/test/java/io/github/belgif/rest/guide/validator/rules/oas/MandatoryMediaTypeTest.java
@@ -14,4 +14,9 @@ class MandatoryMediaTypeTest extends AbstractOasRuleTest {
     void testInvalidOpenApi() {
         assertErrorCount(10, callRules("openapi_bad.yaml"));
     }
+
+    @Test
+    void testStringTypes() {
+        assertNoViolations(callRules("stringTypes.yaml"));
+    }
 }

--- a/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/mandatoryMediaType/stringTypes.yaml
+++ b/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/mandatoryMediaType/stringTypes.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: TestCase
-  description: Here all the request and response bodies are of type object
+  description: This testcase uses a text/html response
   version: '1.0'
 servers:
   - url: '/api/v1'

--- a/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/mandatoryMediaType/stringTypes.yaml
+++ b/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/mandatoryMediaType/stringTypes.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.1
+info:
+  title: TestCase
+  description: Here all the request and response bodies are of type object
+  version: '1.0'
+servers:
+  - url: '/api/v1'
+paths:
+  /myStringResponse:
+    get:
+      responses:
+        200:
+          description: string response
+          content:
+            text/html:
+              schema:
+                type: string
+


### PR DESCRIPTION
Just adding text/* to the includedMediaTypes result in something like:
    xmlRequestBody:
      content:
        text/pdf:
          schema:
            type: object
			
to not be flagged.