### PR TITLE
Removed eval() expressions from drools rules.

### DIFF
--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-ApplicationJsonShouldHaveSchema.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-ApplicationJsonShouldHaveSchema.drl
@@ -29,8 +29,7 @@ function void violationJsonRequestOrResponseHasNoSchema(ViolationReport oas, Med
 
 rule "Application/Json should always have a schema (OAS3)"
   when
-    $mediaTypeDefinition : MediaTypeDefinition(/model[schema == null])
-    eval(isMediaTypeIncluded($mediaTypeDefinition.getIdentifier(), Set.of("application/json")))
+    $mediaTypeDefinition : MediaTypeDefinition(/model[schema == null], isMediaTypeIncluded(identifier, Set.of("application/json")))
   then
     violationJsonRequestOrResponseHasNoSchema(oas, $mediaTypeDefinition);
 end

--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-CodesShouldBeLowerCamelCase.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-CodesShouldBeLowerCamelCase.drl
@@ -18,14 +18,15 @@ function void violationCodesShouldBeLowerCamelCase(ViolationReport oas, SchemaDe
     "New code types SHOULD be represented as string values in lowerCamelCase.", schema);
 }
 
-rule "Codes should io lowerCamelCase"
+rule "Codes should be lowerCamelCase"
     when
-        $schema: SchemaDefinition($schemaType: /model/type)
+        $schema: SchemaDefinition($schemaType: /model/type, ApiFunctions.isNotInSet(identifier, excludeCodes()))
         SchemaType( equals(SchemaType.STRING) ) from $schemaType
         Schema( enumeration != null ) from $schema.getModel()
-        eval(((!$schema.getEffectiveIdentifier().contains("sort") && !$schema.getEffectiveIdentifier().contains("Sort")) && !ApiFunctions.isLowerCamelCase($schema.getModel().getEnumeration()))
-        || (( $schema.getEffectiveIdentifier().contains("sort") || $schema.getEffectiveIdentifier().contains("Sort")) && !ApiFunctions.isLowerCamelCase($schema.getModel().getEnumeration(), "-")))
-        eval( ApiFunctions.isNotInSet($schema.getIdentifier(), excludeCodes()) )
+        String(
+          ((!this.contains("sort") && !this.contains("Sort")) && !ApiFunctions.isLowerCamelCase($schema.getModel().getEnumeration()))
+          || (( this.contains("sort") || this.contains("Sort")) && !ApiFunctions.isLowerCamelCase($schema.getModel().getEnumeration(), "-"))
+        ) from $schema.getEffectiveIdentifier()
     then
         violationCodesShouldBeLowerCamelCase(oas, $schema);
 end

--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-ComponentNamesShouldBeUpperCamelCase.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-ComponentNamesShouldBeUpperCamelCase.drl
@@ -14,11 +14,10 @@ function void violationComponentNamesShouldBeUpperCamelCase(ViolationReport oas,
     "Component names SHOULD use UpperCamelCase notation. For abbreviations as well, all letters except the first one should be lowercased.", component);
 }
 
-rule "Component names should io UpperCamelCase"
+rule "Component names should be UpperCamelCase"
     when
-        $component: OpenApiDefinition(definitionType == DefinitionType.TOP_LEVEL, $jsonPointer: jsonPointer.toPrettyString(), $componentName: identifier)
+        $component: OpenApiDefinition(definitionType == DefinitionType.TOP_LEVEL, $jsonPointer: jsonPointer.toPrettyString(), !ApiFunctions.isUpperCamelCase(identifier))
         String( startsWith("/components") ) from $jsonPointer
-        eval( !ApiFunctions.isUpperCamelCase($componentName) )
     then
         violationComponentNamesShouldBeUpperCamelCase(oas, $component);
 end

--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-ErrorResponseShouldProduceProblemJson.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-ErrorResponseShouldProduceProblemJson.drl
@@ -27,12 +27,11 @@ rule "Error Response with problem+json media type is missing"
   when
     $operationDefinition: OperationDefinition(method != HttpMethod.HEAD && method != HttpMethod.OPTIONS)
     OperationDefinition($statusCode: /model/responses/APIResponses/keySet#String) from $operationDefinition
-    String( this.startsWith("4") || this.startsWith("5") || this == "default" ) from $statusCode
+    String( (this.startsWith("4") || this.startsWith("5") || this == "default") && !($operationDefinition.identifier == "GET /health" && this == "503") ) from $statusCode
     $response: APIResponse() from $operationDefinition.getModel().getResponses().getAPIResponse($statusCode)
     not(APIResponse(/content/mediaTypes[keySet contains "application/problem+json"]) from $response)
     $responseDefinition: ResponseDefinition() from parserResult.resolve($response)
     not(ResponseDefinition(/model/content/mediaTypes[keySet contains "application/problem+json"]) from $responseDefinition)
-    eval( !("GET /health".equals($operationDefinition.getIdentifier()) && "503".equals($statusCode)) )
   then
     violationErrorResponseWrongMediaType(oas, $operationDefinition, $responseDefinition);
 end

--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-HeadersUpperKebabCase.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-HeadersUpperKebabCase.drl
@@ -30,18 +30,14 @@ rule "RequestHeader parameter should be Upper-Kebab-Case"
   when
     $parameterDefinition: ParameterDefinition($in: /model/in)
     Parameter.In(this.equals(In.HEADER)) from $in
-    ParameterDefinition($parameterName: /model/name) from $parameterDefinition
-    eval( ApiFunctions.isNotInSet($parameterName, excludeHeaders()) )
-    eval( !ApiFunctions.isUpperKebabCase($parameterName) )
+    ParameterDefinition($parameterName: /model/name, ApiFunctions.isNotInSet($parameterName, excludeHeaders()) && !ApiFunctions.isUpperKebabCase($parameterName)) from $parameterDefinition
   then
     violationRequestHeaderParam(oas, $parameterDefinition, $parameterName);
 end
 
 rule "ResponseHeader should be Upper-Kebab-Case"
   when
-    $response: ResponseDefinition($headerName: /model/headers/keySet#String)
-    eval( ApiFunctions.isNotInSet($headerName, excludeHeaders()) )
-    eval( !ApiFunctions.isUpperKebabCase($headerName) )
+    $response: ResponseDefinition($headerName: /model/headers/keySet#String, ApiFunctions.isNotInSet($headerName, excludeHeaders()) && !ApiFunctions.isUpperKebabCase($headerName))
   then
     violationResponseHeaderParam(oas, $response, $headerName);
 end

--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-IdName.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-IdName.drl
@@ -23,8 +23,7 @@ function Set forbiddenPathParamNames() {
 rule "Rule-IdName"
     when
         $param: ParameterDefinition(model.getIn() == In.PATH)
-        ParameterDefinition($name: /model/name) from $param
-        eval ( forbiddenPathParamNames().contains($name) )
+        ParameterDefinition($name: /model/name, forbiddenPathParamNames().contains($name)) from $param
     then
         pathParamViolation(oas, $param);
 end

--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-JsonObjectAsTopLevelStructure.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-JsonObjectAsTopLevelStructure.drl
@@ -22,10 +22,8 @@ function void violationJsonObjectAsTopLevelStructure(ViolationReport oas, MediaT
 
 rule "[evo-object] JSON object as top level structure"
   when
-    $mediaTypeDefinition: MediaTypeDefinition()
-    eval(ApiFunctions.isMediaTypeIncluded($mediaTypeDefinition.getIdentifier(), includeContentTypes()))
-    MediaTypeDefinition($schema: /model/schema) from $mediaTypeDefinition
-    eval( ApiFunctions.isSchemaOfType($schema, SchemaType.OBJECT, parserResult) == false )
+    $mediaTypeDefinition: MediaTypeDefinition(ApiFunctions.isMediaTypeIncluded(identifier, includeContentTypes()))
+    MediaTypeDefinition($schema: /model/schema, !ApiFunctions.isSchemaOfType($schema, SchemaType.OBJECT, parserResult)) from $mediaTypeDefinition
   then
     violationJsonObjectAsTopLevelStructure(oas, $mediaTypeDefinition);
 end

--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-MandatoryMediaType.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-MandatoryMediaType.drl
@@ -24,11 +24,9 @@ function void violationMandatoryMediaType(ViolationReport oas, MediaTypeDefiniti
 rule "Mandatory Mediatype"
   when
     $mediaTypeDefinition: MediaTypeDefinition($schema: /model/schema)
-    eval( $schema != null )
     $schemaDefinition: SchemaDefinition(model.getType() != SchemaType.STRING || (model.getFormat() != "binary" && model.getFormat != "byte" && model.getFormat != "base64")) from parserResult.resolve($schema)
-    eval( !ApiFunctions.isMediaTypeIncluded($mediaTypeDefinition.getIdentifier(), includedMediaTypes()) )
+    MediaTypeDefinition(!ApiFunctions.isMediaTypeIncluded(identifier, includedMediaTypes()) && !(ApiFunctions.isMediaTypeIncluded(identifier, Set.of("text/*")) && $schemaDefinition.getModel().getType().equals(SchemaType.STRING))) from $mediaTypeDefinition
     // text/* should only be allowed for type string, not for objects
-    eval( !(ApiFunctions.isMediaTypeIncluded($mediaTypeDefinition.getIdentifier(), Set.of("text/*")) && $schemaDefinition.getModel().getType().equals(SchemaType.STRING)) )
   then
     violationMandatoryMediaType(oas, $mediaTypeDefinition);
 end

--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-PathCamelCase.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-PathCamelCase.drl
@@ -34,8 +34,7 @@ rule "Path CamelCase"
         $path: PathDefinition(directPath == true, $pathString: identifier )
         String(!this.endsWith("/doc/openapi.json") && !this.endsWith("/doc/openapi.yaml")) from $pathString
         String($pathSegmentList: this.split("/")) from $pathString
-        $pathSegment: String( !this.equals("") && !this.startsWith("{") && !this.endsWith("}")) from $pathSegmentList
-        eval( !ApiFunctions.isLowerCamelCase($pathSegment) )
+        String( !this.equals("") && !this.startsWith("{") && !this.endsWith("}") && !ApiFunctions.isLowerCamelCase(this)) from $pathSegmentList
     then
         violationPath(oas, $path);
 end
@@ -44,8 +43,7 @@ rule "Path Parameter CamelCase"
   when
     $parameterDefinition: ParameterDefinition($in: /model/in)
     Parameter.In(this.equals(In.PATH)) from $in
-    ParameterDefinition($parameterName: /model/name) from $parameterDefinition
-    eval( !ApiFunctions.isLowerCamelCase($parameterName) )
+    ParameterDefinition($parameterName: /model/name, !ApiFunctions.isLowerCamelCase($parameterName)) from $parameterDefinition
   then
     violationPathParam(oas, $parameterDefinition);
 end
@@ -54,8 +52,7 @@ rule "Query Parameter lowerCamelCase with extra characters"
   when
     $parameterDefinition: ParameterDefinition($in: /model/in)
     Parameter.In(this.equals(In.QUERY)) from $in
-    ParameterDefinition($parameterName: /model/name) from $parameterDefinition
-    eval( !ApiFunctions.isLowerCamelCase($parameterName, List.of(".", "_")) )
+    ParameterDefinition($parameterName: /model/name, !ApiFunctions.isLowerCamelCase($parameterName, List.of(".", "_"))) from $parameterDefinition
   then
     violationQueryParam(oas, $parameterDefinition);
 end

--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-PathInPlural.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-PathInPlural.drl
@@ -37,8 +37,7 @@ rule "Rule-PathInPlural"
     when
         $path: PathDefinition(directPath == true, $pathName: identifier)
         PathDefinition($operation: /model/GET) from parserResult.resolve($path.getModel())
-        $operationDefinition: OperationDefinition() from parserResult.resolve($operation)
-        eval( hasCollectionResponse($operationDefinition, parserResult) || ApiFunctions.existsPathWithPathParamAfter($pathName, parserResult) )
+        OperationDefinition(hasCollectionResponse(this, parserResult) || ApiFunctions.existsPathWithPathParamAfter($pathName, parserResult)) from parserResult.resolve($operation)
         String( !this.endsWith("}") && !this.endsWith("s") && !this.endsWith("data") && !this.endsWith("Data") && !this.endsWith("/history") ) from $pathName
     then
         pluralViolation(oas, $path);

--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-PresenceOfHealthOperation.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-PresenceOfHealthOperation.drl
@@ -40,8 +40,7 @@ function void healthGetOperationViolation(ViolationReport oas, PathDefinition pa
 
 rule "Rule-PresenceOfHealthOperation"
     when
-      $pathsDefinition: PathsDefinition(inMainFile == true, $paths: /model)
-      eval( !$paths.hasPathItem("/health") && $paths.getPathItems().size() != 0 )
+      $pathsDefinition: PathsDefinition(inMainFile == true, !model.hasPathItem("/health") && model.getPathItems().size() != 0)
     then
         healthViolation(oas, $pathsDefinition);
 end
@@ -51,8 +50,7 @@ rule "Rule-ResponsesOfHealthOperation"
     when
         $path: PathDefinition((identifier == "/health" && directPath == true))
         $resolvedPath: PathDefinition($operation: /model/GET) from parserResult.resolve($path.getModel())
-        $operationDefinition: OperationDefinition($responses: /model/responses) from parserResult.resolve($operation)
-        eval ( !$responses.hasAPIResponse("200") || !$responses.hasAPIResponse("503") )
+        $operationDefinition: OperationDefinition($responses: /model/responses, !$responses.hasAPIResponse("200") || !$responses.hasAPIResponse("503")) from parserResult.resolve($operation)
     then
         healthResponseViolation(oas, $operationDefinition);
 end
@@ -60,8 +58,7 @@ end
 rule "Rule-HealthOperationWithoutGet"
     when
         $path: PathDefinition(identifier == "/health" && directPath == true)
-        $pathItem: PathItem() from parserResult.resolve($path.getModel()).getModel()
-        eval ( $pathItem.getGET() == null )
+        PathItem(getGET() == null) from parserResult.resolve($path.getModel()).getModel()
     then
         healthGetOperationViolation(oas, $path);
 end

--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-ProblemJsonNotAllowedWithSuccessfulStatusCode.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-ProblemJsonNotAllowedWithSuccessfulStatusCode.drl
@@ -23,8 +23,7 @@ rule "application/problem+json not allowed in 1xx, 2xx and 3xx responses"
   when
     $response: ResponseDefinition( definitionType == DefinitionType.INLINE )
     String( startsWith("1") || startsWith("2") || startsWith("3") ) from $response.statusCode
-    ResponseDefinition($mediaType: /model/content/mediaTypes/entrySet/key#String) from parserResult.resolve($response.getModel())
-    eval( ApiFunctions.isMediaTypeIncluded($mediaType, Set.of("application/problem+json")) )
+    ResponseDefinition($mediaType: /model/content/mediaTypes/entrySet/key#String, ApiFunctions.isMediaTypeIncluded($mediaType, Set.of("application/problem+json"))) from parserResult.resolve($response.getModel())
   then
     violationProblemJson(oas, $response);
 end

--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-PropertiesCamelCase.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-PropertiesCamelCase.drl
@@ -15,8 +15,7 @@ function void violationPropertiesCamelCase(ViolationReport oas, String propertyN
 
 rule "Properties CamelCase"
 	when
-        $schema: SchemaDefinition($propertyName: /model/properties/keySet#String)
-        eval( !ApiFunctions.isLowerCamelCase($propertyName) )
+        $schema: SchemaDefinition($propertyName: /model/properties/keySet#String, !ApiFunctions.isLowerCamelCase($propertyName))
     then
         violationPropertiesCamelCase(oas, $propertyName, $schema);
 end

--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-PropertiesNullable.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-PropertiesNullable.drl
@@ -42,8 +42,7 @@ function boolean schemaUsedInPatchOperation(SchemaDefinition schema) {
 
 rule "Rule Properties Nullable"
    	when
-      $schema: SchemaDefinition(model.nullable == true)
-      eval( !hasPatchOrUpdateInTopLevelComponentName($schema) && !schemaUsedInPatchOperation($schema) )
+      $schema: SchemaDefinition(model.nullable == true && !hasPatchOrUpdateInTopLevelComponentName(this) && !schemaUsedInPatchOperation(this))
     then
       violationPropertiesNullable(oas, $schema);
 end

--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-ReadOnlyProperties.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-ReadOnlyProperties.drl
@@ -21,8 +21,7 @@ rule "ReadOnly Properties"
     when
         $schema: SchemaDefinition(model.getRef() == null)
         Map($property: /entrySet) from ApiFunctions.getRecursiveProperties($schema.getModel(), parserResult)
-        $propertyKey: String() from $property.getKey()
-        eval ( ApiFunctions.isPropertyRequiredAndReadOnly($schema, $propertyKey, parserResult) )
+        $propertyKey: String(ApiFunctions.isPropertyRequiredAndReadOnly($schema, this, parserResult)) from $property.getKey()
     then
         violationReadOnlyProperties(oas, $schema, $propertyKey);
 end

--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-RepresentationOfCollection.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-RepresentationOfCollection.drl
@@ -52,14 +52,10 @@ function boolean isObjectType(Schema schema, ParserResult parserResult) {
 rule "Rule-Representation Of Collection should have items property of type array"
     when
        $path: PathDefinition(directPath == true)
-       PathDefinition($operation: /model/GET) from parserResult.resolve($path.getModel())
-       eval( ApiFunctions.existsPathWithPathParamAfter($path.getIdentifier(), parserResult) )
+       PathDefinition($operation: /model/GET, ApiFunctions.existsPathWithPathParamAfter($path.getIdentifier(), parserResult)) from parserResult.resolve($path.getModel())
        $operationDefinition: OperationDefinition($response: /model/responses/APIResponses/entrySet[key#String == "200"]/value#APIResponse) from parserResult.resolve($operation)
-       ResponseDefinition($contentType: /model/content/mediaTypes/entrySet/key#String) from parserResult.resolve($response)
-       eval( ApiFunctions.isMediaTypeIncluded($contentType, Set.of("application/json")) )
-       ResponseDefinition($responseSchema: /model/content/mediaTypes/entrySet[key#String == $contentType]/value#MediaType/schema) from parserResult.resolve($response)
-       eval( isObjectType($responseSchema, parserResult) )
-       eval( !hasItemsArray($responseSchema, parserResult) )
+       ResponseDefinition($contentType: /model/content/mediaTypes/entrySet/key#String, ApiFunctions.isMediaTypeIncluded($contentType, Set.of("application/json"))) from parserResult.resolve($response)
+       ResponseDefinition($responseSchema: /model/content/mediaTypes/entrySet[key#String == $contentType]/value#MediaType/schema, isObjectType($responseSchema, parserResult)&&!hasItemsArray($responseSchema, parserResult)) from parserResult.resolve($response)
     then
         representationOfCollectionArrayViolation(oas, $operationDefinition);
 end
@@ -67,15 +63,10 @@ end
 rule "Rule-Representation Of Collection items in a collection should be of type object"
     when
        $path: PathDefinition(directPath == true)
-       PathDefinition($operation: /model/GET) from parserResult.resolve($path.getModel())
-       eval( ApiFunctions.existsPathWithPathParamAfter($path.getIdentifier(), parserResult) )
+       PathDefinition($operation: /model/GET, ApiFunctions.existsPathWithPathParamAfter($path.getIdentifier(), parserResult)) from parserResult.resolve($path.getModel())
        $operationDefinition: OperationDefinition($response: /model/responses/APIResponses/entrySet[key#String == "200"]/value#APIResponse) from parserResult.resolve($operation)
-       ResponseDefinition($contentType: /model/content/mediaTypes/entrySet/key#String) from parserResult.resolve($response)
-       eval( ApiFunctions.isMediaTypeIncluded($contentType, Set.of("application/json")) )
-       ResponseDefinition($responseSchema: /model/content/mediaTypes/entrySet[key#String == $contentType]/value#MediaType/schema) from parserResult.resolve($response)
-       eval( isObjectType($responseSchema, parserResult) )
-       eval( hasItemsArray($responseSchema, parserResult) )
-       eval( !hasCollectionResponse($responseSchema, parserResult) )
+       ResponseDefinition($contentType: /model/content/mediaTypes/entrySet/key#String, ApiFunctions.isMediaTypeIncluded($contentType, Set.of("application/json"))) from parserResult.resolve($response)
+       ResponseDefinition($responseSchema: /model/content/mediaTypes/entrySet[key#String == $contentType]/value#MediaType/schema, isObjectType($responseSchema, parserResult)&&hasItemsArray($responseSchema, parserResult)&&!hasCollectionResponse($responseSchema, parserResult)) from parserResult.resolve($response)
     then
         representationOfCollectionViolation(oas, $operationDefinition);
 end

--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-ScopesAreDefinedInSecurityScheme.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-ScopesAreDefinedInSecurityScheme.drl
@@ -43,8 +43,7 @@ rule "Rule-ScopesAreDefinedInSecurityScheme"
     $securitySchemeDefinition: SecuritySchemeDefinition(identifier == $securitySchemeName && model.getType()==Type.OAUTH2)
     SecuritySchemeDefinition($flows: /model/flows#OAuthFlows) from $securitySchemeDefinition
     $definedScopes: Set() from fetchScopesFromFlows($flows)
-    $scope: String() from $schemes.getValue()
-    eval ( !$definedScopes.contains($scope) )
+    $scope: String(!$definedScopes.contains(this)) from $schemes.getValue()
   then
     violationScopes(oas, $securityRequirementDefinition, $scope, $securitySchemeDefinition.getPrintableJsonPointer());
 end

--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-ServerUrlFormat.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-ServerUrlFormat.drl
@@ -26,8 +26,7 @@ function boolean hasEntryFilePathsConfigured(ParserResult parserResult) {
 
 rule "Server Url or basePath Format"
     when
-        $server: ServerDefinition($url: /model/url)
-        eval( !parserResult.getSrc().get($server.getOpenApiFile().getAbsolutePath()).hasReusableDefinitionsOnly() && hasEntryFilePathsConfigured(parserResult) )
+        $server: ServerDefinition($url: /model/url, !parserResult.getSrc().get(openApiFile.getAbsolutePath()).hasReusableDefinitionsOnly() && hasEntryFilePathsConfigured(parserResult))
         not String( this matches(urlPattern()) ) from $url
     then
         violationServerUrlFormat(oas, $server);

--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-TagGuidelines.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-TagGuidelines.drl
@@ -55,8 +55,7 @@ end
 rule "Rule-Tag Guidelines each tag should be declared in the top level tags list"
     when
         $path: PathDefinition(directPath == true, $operation: /model/operations/entrySet/value#Operation)
-        $operationDefinition: OperationDefinition($tag: /model/tags#String) from parserResult.resolve($operation)
-        eval( !isTagDeclaredInTopLevelTagsList($tag, parserResult) )
+        $operationDefinition: OperationDefinition($tag: /model/tags#String, !isTagDeclaredInTopLevelTagsList($tag, parserResult)) from parserResult.resolve($operation)
     then
         eachTagShouldBeDeclaredInTheTopLevelTagsListViolation(oas, $operationDefinition, $tag);
 end
@@ -64,8 +63,7 @@ end
 rule "Rule-Tag Guidelines name of tag should start with a capital letter"
     when
         $operationDefinition: OperationDefinition($tag: /model/tags)
-        String(!this.isEmpty()) from $tag
-        eval( !Character.isUpperCase($tag.charAt(0)) )
+        String(!this.isEmpty() && !Character.isUpperCase(this.charAt(0))) from $tag
     then
         nameOfTagShouldStartWithCapitalLetterViolation(oas, $operationDefinition, $tag);
 end

--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-UriExtensions.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-UriExtensions.drl
@@ -14,8 +14,7 @@ function void violationUriExt(ViolationReport oas, PathDefinition path){
 rule "Uri Extensions V3"
    	when
       $path: PathDefinition(directPath == true, $pathUrl: identifier)
-      String( this matches(".+\\..+$") ) from $pathUrl
-      eval( !$pathUrl.equalsIgnoreCase("/doc/openapi.json") && !$pathUrl.equalsIgnoreCase("/doc/openapi.yaml") )
+      String( this matches(".+\\..+$") && !this.equalsIgnoreCase("/doc/openapi.json") && !this.equalsIgnoreCase("/doc/openapi.yaml") ) from $pathUrl
     then
       violationUriExt(oas, $path);
 end

--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-VerifyOperationId.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-VerifyOperationId.drl
@@ -61,24 +61,21 @@ function void violationOperationIdNotLowerCamelCase(ViolationReport oas, Operati
 
 rule "OperationId Not Specified"
 	when
-        $operationDef: OperationDefinition($operation: /model)
-        eval( $operation.getOperationId() == null || $operation.getOperationId().isEmpty() )
+        $operationDef: OperationDefinition($operation: /model, $operation.getOperationId() == null || $operation.getOperationId().isEmpty())
     then
         violationOperationIdNotSpecified(oas, $operationDef);
 end
 
 rule "OperationId Not lowerCamelCase"
   when
-    $operationDef: OperationDefinition($operationId: /model/operationId)
-    eval( !ApiFunctions.isLowerCamelCase($operationId) )
+    $operationDef: OperationDefinition($operationId: /model/operationId, !ApiFunctions.isLowerCamelCase($operationId))
   then
     violationOperationIdNotLowerCamelCase(oas, $operationDef);
 end
 
 rule "OperationId Not Unique"
   when
-    $operations: List() from findDuplicateOperationIds(parserResult.getOperations)
-    eval( $operations.size() > 1 )
+    $operations: List(this.size() > 1) from findDuplicateOperationIds(parserResult.getOperations)
   then
     violationOperationIdNotUnique(oas, $operations);
 end


### PR DESCRIPTION
While invoking the maven plugin. Drools showed some warnings that there were still eval() expressions in the code.
Apparently this is not efficient (anymore) and is seen as code smell.

This PR removes all eval() expressions from the Drools Rules.