### PR TITLE
Verify discriminator mappings correspond to subschemas

### DIFF
--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-OneOfSchema.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-OneOfSchema.drl
@@ -127,25 +127,23 @@ function String findSchemasThatAreOnlyDefinedInOneOfOrDiscriminatorMapping(Schem
   if (schemasDefinedInOneOf.equals(schemasDefinedInDiscriminatorMapping)) {
     return null;
   }
-  String error = null;
+  StringBuilder errorBuilder = new StringBuilder();
   Set<SchemaDefinition> onlyInOneOf = new HashSet<>(schemasDefinedInOneOf);
   onlyInOneOf.removeAll(schemasDefinedInDiscriminatorMapping);
   if (!onlyInOneOf.isEmpty()) {
-    error = "Schemas defined in oneOf but not in discriminator mappings: ";
-    error = error + onlyInOneOf.stream().map(SchemaDefinition::getPrintableJsonPointer).collect(Collectors.joining(", "));
+    errorBuilder.append("Schemas defined in oneOf but not in discriminator mappings: ");
+    errorBuilder.append(onlyInOneOf.stream().map(SchemaDefinition::getPrintableJsonPointer).collect(Collectors.joining(", ")));
   }
   Set<SchemaDefinition> onlyInDiscriminatorMapping = new HashSet<>(schemasDefinedInDiscriminatorMapping);
   onlyInDiscriminatorMapping.removeAll(schemasDefinedInOneOf);
   if (!onlyInDiscriminatorMapping.isEmpty()) {
-    if (error != null) {
-      error = error + "\n";
-    } else {
-      error = "";
+    if (!errorBuilder.isEmpty()) {
+      errorBuilder.append("\n");
     }
-    error = error + "Schemas defined in discriminator mappings but not in oneOf: ";
-    error = error + onlyInDiscriminatorMapping.stream().map(SchemaDefinition::getPrintableJsonPointer).collect(Collectors.joining(", "));
+    errorBuilder.append("Schemas defined in discriminator mappings but not in oneOf: ");
+    errorBuilder.append(onlyInDiscriminatorMapping.stream().map(SchemaDefinition::getPrintableJsonPointer).collect(Collectors.joining(", ")));
   }
-  return error;
+  return errorBuilder.toString();
 }
 
 rule "OneOf use should be limited"

--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-OneOfSchema.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-OneOfSchema.drl
@@ -40,7 +40,7 @@ function void violationOneOfSubSchemaWithEnumOfDifferentType(ViolationReport oas
 
 function void violationOneOfSchemasCorrespondToDiscriminatorMappings(ViolationReport oas, SchemaDefinition schema, String errorMessage) {
     oas.addViolation("[sch-oneof]",
-        "All `oneOf` subschemas should be present in the discriminator mapping", errorMessage, schema, ViolationLevel.RECOMMENDED);
+        "The schemas used in the discriminator mapping should be the same as the `oneOf` subschemas.", errorMessage, schema, ViolationLevel.RECOMMENDED);
 }
 
 function String createErrorMessage(SchemaDefinition oneOfSchemaDef, List<String> props) {

--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-OneOfSchema.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-OneOfSchema.drl
@@ -20,7 +20,8 @@ import java.util.ArrayList;
 import java.util.Collections
 import java.util.stream.Collectors
 import java.util.Map
-import java.util.stream.Stream;
+import java.util.stream.Stream
+import java.util.Optional;
 
 function void violationDiscriminatorPropertyWithOneOf(ViolationReport oas, SchemaDefinition schema, String discriminatorPropertyName){
     oas.addViolation("[sch-oneof]",
@@ -35,6 +36,11 @@ function void violationOneOfSubSchemaAllowedUsage(ViolationReport oas, SchemaDef
 function void violationOneOfSubSchemaWithEnumOfDifferentType(ViolationReport oas, SchemaDefinition schema, String conflictingTypes) {
     oas.addViolation("[sch-oneof]",
         "use of `oneOf` SHOULD be limited to either: 1. subschemas with only a `required` constraint, without a `type` or other constraint 2. subschemas with an `enum` of the same simple `type` (i.e. no `array` or `object`) 3. subschemas of `type: object`, when a `discriminator` is also defined. Properties may only be defined within the subschemas.", "Enforces conflicting enum types: <<" + conflictingTypes + ">>", schema, ViolationLevel.RECOMMENDED);
+}
+
+function void violationOneOfSchemasCorrespondToDiscriminatorMappings(ViolationReport oas, SchemaDefinition schema, String errorMessage) {
+    oas.addViolation("[sch-oneof]",
+        "All `oneOf` subschemas should be present in the discriminator mapping", errorMessage, schema, ViolationLevel.RECOMMENDED);
 }
 
 function String createErrorMessage(SchemaDefinition oneOfSchemaDef, List<String> props) {
@@ -110,6 +116,38 @@ function String getConflictingTypesInEnum(SchemaDefinition schemaDefinition, Par
   return types.isEmpty() || types.size() == 1 ? null : types.stream().map(SchemaType::toString).collect(Collectors.joining(", ")).toString();
 }
 
+// Returns an error message
+function String findSchemasThatAreOnlyDefinedInOneOfOrDiscriminatorMapping(SchemaDefinition schemaDefinition, ParserResult parserResult) {
+  Set<SchemaDefinition> schemasDefinedInOneOf = schemaDefinition.getModel().getOneOf().stream().map(s -> (SchemaDefinition) parserResult.resolve(s)).collect(Collectors.toSet());
+  Set<SchemaDefinition> schemasDefinedInDiscriminatorMapping = schemaDefinition.getModel().getDiscriminator().getMapping().values().stream()
+    .map(s -> parserResult.resolveDiscriminatorMapping(schemaDefinition, s))
+    .filter(Optional::isPresent)
+    .map(Optional::get)
+    .collect(Collectors.toSet());
+  if (schemasDefinedInOneOf.equals(schemasDefinedInDiscriminatorMapping)) {
+    return null;
+  }
+  String error = null;
+  Set<SchemaDefinition> onlyInOneOf = new HashSet<>(schemasDefinedInOneOf);
+  onlyInOneOf.removeAll(schemasDefinedInDiscriminatorMapping);
+  if (!onlyInOneOf.isEmpty()) {
+    error = "Schemas defined in oneOf but not in discriminator mappings: ";
+    error = error + onlyInOneOf.stream().map(SchemaDefinition::getPrintableJsonPointer).collect(Collectors.joining(", "));
+  }
+  Set<SchemaDefinition> onlyInDiscriminatorMapping = new HashSet<>(schemasDefinedInDiscriminatorMapping);
+  onlyInDiscriminatorMapping.removeAll(schemasDefinedInOneOf);
+  if (!onlyInDiscriminatorMapping.isEmpty()) {
+    if (error != null) {
+      error = error + "\n";
+    } else {
+      error = "";
+    }
+    error = error + "Schemas defined in discriminator mappings but not in oneOf: ";
+    error = error + onlyInDiscriminatorMapping.stream().map(SchemaDefinition::getPrintableJsonPointer).collect(Collectors.joining(", "));
+  }
+  return error;
+}
+
 rule "OneOf use should be limited"
     when
         $schemaDefinition: SchemaDefinition(model.getOneOf() != null)
@@ -133,4 +171,12 @@ rule "Property with discriminator.propertyName as name should be defined in each
         $subSchema: SchemaDefinition( !ApiFunctions.getRecursiveProperties(getModel(), parserResult).containsKey($discriminatorPropertyName) || !ApiFunctions.getRequiredProperties(this, parserResult, true).contains($discriminatorPropertyName) ) from parserResult.resolve($oneOf)
     then
         violationDiscriminatorPropertyWithOneOf(oas, $subSchema, $discriminatorPropertyName);
+end
+
+rule "Discriminator mappings should contain all oneOf subschemas"
+    when
+        $schema: SchemaDefinition(model.getOneOf() != null && model.getDiscriminator() != null && model.getDiscriminator().getMapping() != null)
+        $error: String() from findSchemasThatAreOnlyDefinedInOneOfOrDiscriminatorMapping($schema, parserResult)
+    then
+        violationOneOfSchemasCorrespondToDiscriminatorMappings(oas, $schema, $error);
 end

--- a/rules/src/test/java/io/github/belgif/rest/guide/validator/rules/oas/OneOfSchemaTest.java
+++ b/rules/src/test/java/io/github/belgif/rest/guide/validator/rules/oas/OneOfSchemaTest.java
@@ -82,6 +82,6 @@ class OneOfSchemaTest extends AbstractOasRuleTest {
 
     @Test
     void testOneOfSchemasAndDiscriminatorMappingsDoNotCorrespond() {
-        assertErrorCount(30, callRules("oneOfSchemasAndDiscriminatorMappingsDoNotCorrespond.yaml"));
+        assertErrorCount(3, callRules("oneOfSchemasAndDiscriminatorMappingsDoNotCorrespond.yaml"));
     }
 }

--- a/rules/src/test/java/io/github/belgif/rest/guide/validator/rules/oas/OneOfSchemaTest.java
+++ b/rules/src/test/java/io/github/belgif/rest/guide/validator/rules/oas/OneOfSchemaTest.java
@@ -56,7 +56,7 @@ class OneOfSchemaTest extends AbstractOasRuleTest {
     @Test
     void testNonCombinableSubSchemas() {
         ViolationReport report = callRules("nonCombinableOneOfSchemas.yaml");
-        assertErrorCount(2, report);
+        assertErrorCount(3, report);
         assertEquals("All subschemas should comply with one of the allowed uses for a oneOf schema.", report.getViolations().get(0).getMessage());
     }
 
@@ -78,5 +78,10 @@ class OneOfSchemaTest extends AbstractOasRuleTest {
     @Test
     void testOneOfDiscriminatorPropertyNotRequired() {
         assertErrorCount(1, callRules("oneOfDiscriminatorPropertyNotRequired.yaml"));
+    }
+
+    @Test
+    void testOneOfSchemasAndDiscriminatorMappingsDoNotCorrespond() {
+        assertErrorCount(30, callRules("oneOfSchemasAndDiscriminatorMappingsDoNotCorrespond.yaml"));
     }
 }

--- a/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/oneOfSchema/oneOfSchemasAndDiscriminatorMappingsDoNotCorrespond.yaml
+++ b/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/oneOfSchema/oneOfSchemasAndDiscriminatorMappingsDoNotCorrespond.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.1
+info:
+  title: TestCase
+  version: '1.0'
+servers:
+  - url: '/api/v1'
+paths: {}
+components:
+  schemas:
+    DiscriminatorMappingsDoNotCorrespond:
+      discriminator:
+        propertyName: type
+        mapping:
+          first: "#/components/schemas/SchemaOne"
+      oneOf:
+        - $ref: '#/components/schemas/SchemaOne'
+        - $ref: '#/components/schemas/SchemaTwo'
+    OneOfDoesNotCorrespond:
+      discriminator:
+        propertyName: type
+        mapping:
+          first: "#/components/schemas/SchemaOne"
+          second: "#/components/schemas/SchemaTwo"
+      oneOf:
+        - $ref: '#/components/schemas/SchemaOne'
+    DoesNotMatchAtAll:
+      discriminator:
+        propertyName: type
+        mapping:
+          first: "#/components/schemas/SchemaOne"
+      oneOf:
+        - $ref: '#/components/schemas/SchemaTwo'
+    SchemaOne:
+      type: object
+      properties:
+        firstProperty:
+          type: string
+        type:
+          type: string
+      required:
+        - type
+    SchemaTwo:
+      type: object
+      properties:
+        secondProperty:
+          type: string
+        type:
+          type: string
+      required:
+        - type


### PR DESCRIPTION
Please review validation level (recommended) and error message.
```
[RECOMMENDED]  [sch-oneof]    oneOfSchemasAndDiscriminatorMappingsDoNotCorrespond.yaml ln  10  #/components/schemas/DiscriminatorMappingsDoNotCorrespond: 
All `oneOf` subschemas should be present in the discriminator mapping -- Schemas defined in oneOf but not in discriminator mappings: /components/schemas/SchemaTwo
[RECOMMENDED]  [sch-oneof]    oneOfSchemasAndDiscriminatorMappingsDoNotCorrespond.yaml ln  18  #/components/schemas/OneOfDoesNotCorrespond: 
All `oneOf` subschemas should be present in the discriminator mapping -- Schemas defined in discriminator mappings but not in oneOf: /components/schemas/SchemaTwo
[RECOMMENDED]  [sch-oneof]    oneOfSchemasAndDiscriminatorMappingsDoNotCorrespond.yaml ln  26  #/components/schemas/DoesNotMatchAtAll: 
All `oneOf` subschemas should be present in the discriminator mapping
-- Schemas defined in oneOf but not in discriminator mappings: /components/schemas/SchemaTwo
-- Schemas defined in discriminator mappings but not in oneOf: /components/schemas/SchemaOne ==> 
```