### PR TITLE
Fix: don't check [hlth-res] when x-reusable-definitions-only is true

### DIFF
--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-PresenceOfHealthOperation.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-PresenceOfHealthOperation.drl
@@ -48,7 +48,7 @@ end
 
 rule "Rule-ResponsesOfHealthOperation"
     when
-        $path: PathDefinition(identifier == "/health")
+        $path: PathDefinition(identifier == "/health" && inEntryDocument())
         $resolvedPath: PathDefinition($operation: /model/GET) from parserResult.resolve($path.getModel())
         $operationDefinition: OperationDefinition($responses: /model/responses, !$responses.hasAPIResponse("200") || !$responses.hasAPIResponse("503")) from parserResult.resolve($operation)
     then
@@ -57,7 +57,7 @@ end
 
 rule "Rule-HealthOperationWithoutGet"
     when
-        $path: PathDefinition(identifier == "/health")
+        $path: PathDefinition(identifier == "/health" && inEntryDocument())
         PathItem(getGET() == null) from parserResult.resolve($path.getModel()).getModel()
     then
         healthGetOperationViolation(oas, $path);

--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-PresenceOfHealthOperation.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-PresenceOfHealthOperation.drl
@@ -40,7 +40,7 @@ function void healthGetOperationViolation(ViolationReport oas, PathDefinition pa
 
 rule "Rule-PresenceOfHealthOperation"
     when
-      $pathsDefinition: PathsDefinition(inMainFile == true, !model.hasPathItem("/health") && model.getPathItems().size() != 0)
+      $pathsDefinition: PathsDefinition(inMainFile == true, !model.hasPathItem("/health") && model.getPathItems().size() != 0 && !parserResult.getSrc().get(openApiFile.absolutePath).hasReusableDefinitionsOnly())
     then
         healthViolation(oas, $pathsDefinition);
 end
@@ -48,7 +48,7 @@ end
 
 rule "Rule-ResponsesOfHealthOperation"
     when
-        $path: PathDefinition((identifier == "/health" && directPath == true))
+        $path: PathDefinition(identifier == "/health")
         $resolvedPath: PathDefinition($operation: /model/GET) from parserResult.resolve($path.getModel())
         $operationDefinition: OperationDefinition($responses: /model/responses, !$responses.hasAPIResponse("200") || !$responses.hasAPIResponse("503")) from parserResult.resolve($operation)
     then
@@ -57,7 +57,7 @@ end
 
 rule "Rule-HealthOperationWithoutGet"
     when
-        $path: PathDefinition(identifier == "/health" && directPath == true)
+        $path: PathDefinition(identifier == "/health")
         PathItem(getGET() == null) from parserResult.resolve($path.getModel()).getModel()
     then
         healthGetOperationViolation(oas, $path);

--- a/rules/src/test/java/io/github/belgif/rest/guide/validator/rules/oas/PresenceOfHealthOperationTest.java
+++ b/rules/src/test/java/io/github/belgif/rest/guide/validator/rules/oas/PresenceOfHealthOperationTest.java
@@ -38,4 +38,14 @@ class PresenceOfHealthOperationTest extends AbstractOasRuleTest {
     void testReferencedHealthOperation() {
         assertNoViolations(callRules("referencedHealthOperation.yaml"));
     }
+
+    @Test
+    void absenceOfHealthOperationAllowedInReusableDefinitionsOnlyFile() {
+        assertNoViolations(callRules("reusableDefinitions.yaml"));
+    }
+
+    @Test
+    void invalidHealthOperationInReusableDefinitionsFile() {
+        assertErrorCount(1, callRules("invalidHealthOperationInReusableDefinitionsFile.yaml"));
+    }
 }

--- a/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/presenceOfHealthOperation/invalidHealthOperationInReusableDefinitionsFile.yaml
+++ b/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/presenceOfHealthOperation/invalidHealthOperationInReusableDefinitionsFile.yaml
@@ -1,0 +1,23 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Health
+servers:
+  - url: http://myServer.com
+x-reusable-definitions-only: true
+paths:
+  /health:
+    get:
+      responses:
+        200:
+          description: good
+          content:
+            application/json:
+              schema:
+                type: object
+        default:
+          description: default description
+          content:
+            application/json:
+              schema:
+                type: object

--- a/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/presenceOfHealthOperation/reusableDefinitions.yaml
+++ b/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/presenceOfHealthOperation/reusableDefinitions.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: OpenApi describing the doc resources
+  version: v1
+tags:
+  - name: Documentation
+    description: Documentation of this API
+x-reusable-definitions-only: true
+paths:
+  /doc/openapi.yaml:
+    get:
+      tags:
+        - Documentation
+      summary: Returns the API documentation in OpenAPI 3 YAML format
+      operationId: getOpenApi
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/yaml:
+              schema:
+                "$ref": "#/components/schemas/OpenApi"
+        default:
+          description: problem
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+      security: []
+components:
+  schemas:
+    OpenApi:
+      type: string
+      format: binary
+    Problem:
+      type: object


### PR DESCRIPTION
- Presence of health endpoint is not checked anymore if x-reusable-definitions-only is set to true
- Rest of the health rules do still apply IF an endpoint is present. But only in entryDocument (because it's a path)