### PR TITLE
Implemented rule ReferencesShouldPointToTopLevelDefinitions

### DIFF
--- a/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-ReferencesShouldPointToTopLevelDefinitions.drl
+++ b/rules/src/main/resources/io/github/belgif/rest/guide/validator/rules/oas/Rule-ReferencesShouldPointToTopLevelDefinitions.drl
@@ -1,0 +1,36 @@
+package io.github.belgif.rest.guide.validator.rules.oas;
+
+import io.github.belgif.rest.guide.validator.core.ViolationReport;
+global io.github.belgif.rest.guide.validator.core.ViolationReport oas;
+import io.github.belgif.rest.guide.validator.core.model.OpenApiDefinition;
+import io.github.belgif.rest.guide.validator.core.model.SchemaDefinition;
+import io.github.belgif.rest.guide.validator.core.ViolationLevel;
+import org.eclipse.microprofile.openapi.models.Reference;
+global io.github.belgif.rest.guide.validator.core.parser.Parser.ParserResult parserResult;
+import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.eclipse.microprofile.openapi.models.media.Discriminator;
+
+function void violationReferencesShouldPointToTopLevelDefinitions(ViolationReport oas, OpenApiDefinition<?> def, String violatingReference) {
+  oas.addViolation("[oas-comp]",
+      "A $ref SHOULD reference a definition of the expected type under /components/<definitionTypes>/<componentName>", "Found reference to: <<" + violatingReference + ">>", def, ViolationLevel.RECOMMENDED);
+}
+
+function String findReferenceFromComponent(OpenApiDefinition def) {
+  return ((Reference<?>) def.getModel()).getRef();
+}
+
+rule "References should point to top-level definitions"
+    when
+        $component: OpenApiDefinition(hasReference())
+        OpenApiDefinition(DefinitionType != DefinitionType.TOP_LEVEL) from parserResult.resolve($component.getModel())
+    then
+        violationReferencesShouldPointToTopLevelDefinitions(oas, $component, ((Reference<?>) $component.getModel()).getRef());
+end
+
+rule "Discriminator mappings should point to top-level definitions"
+    when
+        $schema: SchemaDefinition($mapping: /model/discriminator/mapping/values#String)
+        OpenApiDefinition(DefinitionType != DefinitionType.TOP_LEVEL) from parserResult.resolveDiscriminatorMapping($schema, $mapping).get()
+    then
+        violationReferencesShouldPointToTopLevelDefinitions(oas, $schema, $mapping);
+end

--- a/rules/src/test/java/io/github/belgif/rest/guide/validator/rules/oas/ReferencesShouldPointToTopLevelDefinitionsTest.java
+++ b/rules/src/test/java/io/github/belgif/rest/guide/validator/rules/oas/ReferencesShouldPointToTopLevelDefinitionsTest.java
@@ -1,0 +1,27 @@
+package io.github.belgif.rest.guide.validator.rules.oas;
+
+import io.github.belgif.rest.guide.validator.rules.AbstractOasRuleTest;
+import org.junit.jupiter.api.Test;
+
+class ReferencesShouldPointToTopLevelDefinitionsTest extends AbstractOasRuleTest {
+
+    @Test
+    void testReferenceToTopLevelDefinition() {
+        assertNoViolations(callRules("refToTopLevelDefinition.yaml"));
+    }
+
+    @Test
+    void testReferenceToInlineDefinition() {
+        assertErrorCount(1, callRules("refToInlineDefinition.yaml"));
+    }
+
+    @Test
+    void testDiscriminatorMappingToTopLevelDefinition() {
+        assertNoViolations(callRules("discriminatorMappingToTopLevelDefinition.yaml"));
+    }
+
+    @Test
+    void testDiscriminatorMappingToInlineDefinition() {
+        assertErrorCount(1, callRules("discriminatorMappingToInlineDefinition.yaml"));
+    }
+}

--- a/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/referencesShouldPointToTopLevelDefinitions/discriminatorMappingToInlineDefinition.yaml
+++ b/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/referencesShouldPointToTopLevelDefinitions/discriminatorMappingToInlineDefinition.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.1
+info:
+  title: ReadOnlyProperties
+  version: '1.0'
+servers:
+  - url: '/api/v1'
+paths: { }
+components:
+  schemas:
+    SchemaUnderTest:
+      type: object
+      properties:
+        type:
+          type: string
+      discriminator:
+        propertyName: type
+        mapping:
+          first: '#/components/schemas/First'
+          second: '#/components/schemas/SomethingBig/properties/second'
+
+    First:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/SchemaUnderTest'
+        - properties:
+            myFirstProp:
+              type:"string
+
+    SomethingBig:
+      type: object
+      properties:
+        second:
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/SchemaUnderTest'
+            - properties:
+                somethingElse:
+                  type: string

--- a/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/referencesShouldPointToTopLevelDefinitions/discriminatorMappingToTopLevelDefinition.yaml
+++ b/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/referencesShouldPointToTopLevelDefinitions/discriminatorMappingToTopLevelDefinition.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.1
+info:
+  title: ReadOnlyProperties
+  version: '1.0'
+servers:
+  - url: '/api/v1'
+paths: { }
+components:
+  schemas:
+    SchemaUnderTest:
+      type: object
+      properties:
+        type:
+          type: string
+      discriminator:
+        propertyName: type
+        mapping:
+          first: '#/components/schemas/First'
+          second: '#/components/schemas/SomethingBig'
+
+    First:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/SchemaUnderTest'
+        - properties:
+            myFirstProp:
+              type:"string
+
+    SomethingBig:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/SchemaUnderTest'
+        - properties:
+            somethingElse:
+              type: string

--- a/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/referencesShouldPointToTopLevelDefinitions/refToInlineDefinition.yaml
+++ b/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/referencesShouldPointToTopLevelDefinitions/refToInlineDefinition.yaml
@@ -1,0 +1,30 @@
+openapi: 3.0.1
+info:
+  title: ReadOnlyProperties
+  version: '1.0'
+servers:
+  - url: '/api/v1'
+paths: {}
+components:
+  schemas:
+    SchemaUnderTest:
+      type: object
+      properties:
+        first:
+          $ref: '#/components/schemas/MyPropertiesSchema'
+        second:
+          $ref: '#/components/schemas/MyPropertiesSchema/properties/second'
+    MyPropertiesSchema:
+      type: object
+      properties:
+        first:
+          type: string
+        second:
+          type: object
+          properties:
+            inlineProperty:
+              type: number
+            anotherOne:
+              type: string
+        third:
+          type: number

--- a/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/referencesShouldPointToTopLevelDefinitions/refToTopLevelDefinition.yaml
+++ b/rules/src/test/resources/io/github/belgif/rest/guide/validator/rules/oas/referencesShouldPointToTopLevelDefinitions/refToTopLevelDefinition.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.1
+info:
+  title: ReadOnlyProperties
+  version: '1.0'
+servers:
+  - url: '/api/v1'
+paths: {}
+components:
+  schemas:
+    SchemaUnderTest:
+      type: object
+      properties:
+        first:
+          $ref: '#/components/schemas/MyPropertiesSchema'
+    MyPropertiesSchema:
+      type: object
+      properties:
+        first:
+          type: string
+        second:
+          type: object
+          properties:
+            inlineProperty:
+              type: number
+            anotherOne:
+              type: string
+        third:
+          type: number


### PR DESCRIPTION
Fixes #234 

Errormessage:
```
[RECOMMENDED]  [oas-comp]     refToInlineDefinition.yaml ln  15  #/components/schemas/SchemaUnderTest/properties/second: 
A $ref SHOULD reference a definition of the expected type under /components/<definitionTypes>/<componentName> -- Found reference to: <<#/components/schemas/MyPropertiesSchema/properties/second>>
```

Ready for review.